### PR TITLE
Update accessing-context.md

### DIFF
--- a/docs/accessing-context.md
+++ b/docs/accessing-context.md
@@ -225,8 +225,8 @@ clone the repository and create the necessary images by running the commands as 
 ```bash
 #!/bin/bash
 git clone https://github.com/FIWARE/tutorials.Accessing-Context.git
-git checkout NGSI-v2
 cd tutorials.Accessing-Context
+git checkout NGSI-v2
 
 ./services create; ./services start;
 ```


### PR DESCRIPTION
Update accessing-context.md

The order of the two commands when cloning the repo and then starting the services is corrected. After cloning, we should first change into directory and only then checkout to the branch